### PR TITLE
Merge RSEM counts and TPM across samples

### DIFF
--- a/modules/utility_modules/merge_rsem_counts.nf
+++ b/modules/utility_modules/merge_rsem_counts.nf
@@ -1,0 +1,51 @@
+// adapted from https://github.com/nf-core/rnaseq/blob/3.14.0/modules/local/rsem_merge_counts/main.nf
+process MERGE_RSEM_COUNTS {
+
+  tag ""
+
+  cpus 1  
+  memory 24.GB
+  time 2.h
+  errorStrategy {(task.exitStatus == 140) ? {log.info "\n\nError code: ${task.exitStatus} for task: ${task.name}. Likely caused by the task wall clock: ${task.time} or memory: ${task.memory} being exceeded.\nAttempting orderly shutdown.\nSee .command.log in: ${task.workDir} for more info.\n\n"; return 'finish'}.call() : 'finish'}
+
+  container "quay.io/jaxcompsci/py3_perl_pylibs:v2"
+
+  publishDir "${params.pubdir}", pattern: "rsem.merged.*.tsv", mode:'copy'
+
+  input:
+  path("genes/*")
+  path("isoforms/*")
+
+  output:
+  path "rsem.merged.gene_counts.tsv", emit: gene_counts
+  path "rsem.merged.gene_tpm.tsv", emit: gene_tpm
+  path "rsem.merged.transcript_counts.tsv", emit: transcript_counts
+  path "rsem.merged.transcript_tpm.tsv", emit: transcript_tpm
+  script:
+  """
+  mkdir -p tmp/genes
+  cut -f 1,2 `ls ./genes/* | head -n 1` > gene_ids.txt
+  for fileid in `ls ./genes/*`; do
+    samplename=`basename \$fileid | sed s/\\.genes.results\$//g`
+    echo \$samplename > tmp/genes/\${samplename}.counts.txt
+    cut -f 5 \${fileid} | tail -n+2 >> tmp/genes/\${samplename}.counts.txt
+    echo \$samplename > tmp/genes/\${samplename}.tpm.txt
+    cut -f 6 \${fileid} | tail -n+2 >> tmp/genes/\${samplename}.tpm.txt
+  done
+
+  mkdir -p tmp/isoforms
+  cut -f 1,2 `ls ./isoforms/* | head -n 1` > transcript_ids.txt
+  for fileid in `ls ./isoforms/*`; do
+    samplename=`basename \$fileid | sed s/\\.isoforms.results\$//g`
+    echo \$samplename > tmp/isoforms/\${samplename}.counts.txt
+    cut -f 5 \${fileid} | tail -n+2 >> tmp/isoforms/\${samplename}.counts.txt
+    echo \$samplename > tmp/isoforms/\${samplename}.tpm.txt
+    cut -f 6 \${fileid} | tail -n+2 >> tmp/isoforms/\${samplename}.tpm.txt
+  done
+
+  paste gene_ids.txt tmp/genes/*.counts.txt > rsem.merged.gene_counts.tsv
+  paste gene_ids.txt tmp/genes/*.tpm.txt > rsem.merged.gene_tpm.tsv
+  paste transcript_ids.txt tmp/isoforms/*.counts.txt > rsem.merged.transcript_counts.tsv
+  paste transcript_ids.txt tmp/isoforms/*.tpm.txt > rsem.merged.transcript_tpm.tsv  
+  """
+}

--- a/workflows/rnaseq.nf
+++ b/workflows/rnaseq.nf
@@ -17,6 +17,7 @@ include {FASTQC} from "${projectDir}/modules/fastqc/fastqc"
 include {CHECK_STRANDEDNESS} from "${projectDir}/modules/python/python_check_strandedness"
 include {READ_GROUPS} from "${projectDir}/modules/utility_modules/read_groups"
 include {RSEM_ALIGNMENT_EXPRESSION} from "${projectDir}/modules/rsem/rsem_alignment_expression"
+include {MERGE_RSEM_COUNTS} from "${projectDir}/modules/utility_modules/merge_rsem_counts"
 include {PICARD_ADDORREPLACEREADGROUPS} from "${projectDir}/modules/picard/picard_addorreplacereadgroups"
 include {PICARD_REORDERSAM} from "${projectDir}/modules/picard/picard_reordersam"
 include {PICARD_SORTSAM} from "${projectDir}/modules/picard/picard_sortsam"
@@ -137,6 +138,8 @@ workflow RNASEQ {
     // Step 2: RSEM
     RSEM_ALIGNMENT_EXPRESSION(rsem_input, params.rsem_ref_files, params.rsem_star_prefix, params.rsem_ref_prefix)
 
+    MERGE_RSEM_COUNTS(RSEM_ALIGNMENT_EXPRESSION.out.rsem_genes.collect{it[1]},
+                      RSEM_ALIGNMENT_EXPRESSION.out.rsem_isoforms.collect{it[1]})
     //Step 3: Get Read Group Information
     READ_GROUPS(FASTP.out.trimmed_fastq, "picard")
 


### PR DESCRIPTION
Adapted a module from the nf-core RNA-seq workflow to merge counts across samples and output 4 additional tables to the top-level pubdir 1) gene counts, 2) gene TPM, 3) isoform counts, 4) isoform TPM